### PR TITLE
feat: add sol query for cve-2025-33053 - iediag lolbin exploit

### DIFF
--- a/queries/hunting/iediagcmd_susp_process_tree.sol
+++ b/queries/hunting/iediagcmd_susp_process_tree.sol
@@ -1,0 +1,18 @@
+// name: iediagcmd.exe suspicious tree
+// description: Identify suspicious iediagcmd abnormal process tree, could indicate successful exploitation of CVE-2025-3305
+// author: sekoia.io
+// license: mit
+// tags:
+//   - cve-2025-33053
+//   - stealth falcon apt
+//   - MEA
+// refs:
+//   - https://research.checkpoint.com/2025/stealth-falcon-zero-day/
+// query:
+
+events
+| where timestamp >= (7d)
+| where process.parent.executable == "C:\Program Files\Internet Explorer\iediagcmd.exe"
+| where not process.executable startswith~ "C:\Windows\System32"
+| where process.name in ["route.exe", "ROUTE.EXE", "netsh.exe", "NETSH.EXE", "ipconfig.exe", "IPCONFIG.EXE", "dxdiag.exe", "DXDIAG.EXE"]
+| select timestamp, event.code, host.name, user.name, process.parent.pid, process.parent.executable, process.pid, process.executable, process.name, process.command_line


### PR DESCRIPTION
### quick SOL query for detect iediagabuse

A recent Checkpoint report describes the exploitation of the **CVE-2025-33053** by the **Stealth Falcon APT**. 
A .url file is probably sent to the victim by spearphishing. This file is weaponized and invokes the iediag lolbin, which loads a route.exe payload store on the attacker's staging server.

By default, his utility spawns additional processes to collect diagnostic data, such as:
- ipconfig.exe /all
- netsh.exe in tcp show global
- netsh.exe advfirewall firewall show rule name=all verbose
- route.exe print
The vulnerability CVE-2025-33053 is exploited by abusing Process.Start() function from iediag to launch a malicious .url file, which triggers an automatic WebDAV connection to a remote server using a crafted UNC path

